### PR TITLE
Translate reflection tutorial notebook to Korean

### DIFF
--- a/docs/docs/tutorials/reflection/reflection.ipynb
+++ b/docs/docs/tutorials/reflection/reflection.ipynb
@@ -10,15 +10,28 @@
    "id": "492f050f-3dc3-44fa-8fdc-03362afd5488",
    "metadata": {},
    "source": [
-    "# Reflection\n",
+    "# 반성 (Reflection)\n",
     "\n",
+    "LLM 에이전트를 구축할 때, 반성은 LLM에게 과거 단계(도구나 환경에서 얻은 관찰 결과 포함)를 되돌아보도록 프롬프트하여 선택한 행동의 품질을 평가하게 하는 과정을 의미합니다.\n",
+    "이 정보는 이후 재계획, 탐색, 평가와 같은 작업에 활용됩니다.\n",
     "\n",
-    "In the context of LLM agent building, reflection refers to the process of prompting an LLM to observe its past steps (along with potential observations from tools/the environment) to assess the quality of the chosen actions.\n",
-    "This is then used downstream for things like re-planning, search, or evaluation.\n",
+    "![반성](attachment:fc393f72-3401-4b86-b0d3-e4789b640a27.png)\n",
     "\n",
-    "![Reflection](attachment:fc393f72-3401-4b86-b0d3-e4789b640a27.png)\n",
+    "이 노트북은 LangGraph에서 매우 간단한 형태의 반성 기법을 보여 줍니다."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33f779bf",
+   "metadata": {},
+   "source": [
+    "## 예제 미리 보기\n",
     "\n",
-    "This notebook demonstrates a very simple form of reflection in LangGraph."
+    "이 노트북에서는 \"5단락 에세이\" 생성기를 만들어 반성 루프를 적용하는 예제를 다룹니다.\n",
+    "\n",
+    "1. 사용자의 에세이 요청을 받아 초안(생성 단계)을 작성합니다.\n",
+    "2. 교사 역할의 LLM이 초안을 검토하고 개선점을 제안합니다(반성 단계).\n",
+    "3. 제안을 바탕으로 새로운 초안을 만들고, 원하는 품질에 도달할 때까지 반복합니다."
    ]
   },
   {
@@ -26,9 +39,9 @@
    "id": "3ef94e7e-c9a5-4eee-a865-acf411b5c235",
    "metadata": {},
    "source": [
-    "## Setup\n",
+    "## 환경 설정\n",
     "\n",
-    "First, let's install our required packages and set our API keys"
+    "먼저 필요한 패키지를 설치하고 API 키를 설정하겠습니다."
    ]
   },
   {
@@ -69,9 +82,9 @@
    "metadata": {},
    "source": [
     "<div class=\"admonition tip\">\n",
-    "    <p class=\"admonition-title\">Set up <a href=\"https://smith.langchain.com\">LangSmith</a> for LangGraph development</p>\n",
+    "    <p class=\"admonition-title\"><a href=\"https://smith.langchain.com\">LangSmith</a> 설정으로 LangGraph 개발 시작하기</p>\n",
     "    <p style=\"padding-top: 5px;\">\n",
-    "        Sign up for LangSmith to quickly spot issues and improve the performance of your LangGraph projects. LangSmith lets you use trace data to debug, test, and monitor your LLM apps built with LangGraph — read more about how to get started <a href=\"https://docs.smith.langchain.com\">here</a>. \n",
+    "        LangSmith에 가입하면 LangGraph 프로젝트에서 문제를 빠르게 파악하고 성능을 향상시킬 수 있습니다. LangSmith는 LangGraph로 구축한 LLM 앱의 추적 데이터를 활용해 디버깅, 테스트, 모니터링을 지원합니다 — 자세한 시작 방법은 <a href=\"https://docs.smith.langchain.com\">여기</a>에서 확인하세요.\n",
     "    </p>\n",
     "</div>"
    ]
@@ -81,9 +94,9 @@
    "id": "f27bcc4a-aaa5-46bd-8163-3e0e90cb66e6",
    "metadata": {},
    "source": [
-    "## Generate\n",
+    "## 생성하기\n",
     "\n",
-    "For our example, we will create a \"5 paragraph essay\" generator. First, create the generator:\n"
+    "이 예제에서는 \"5단락 에세이\" 생성기를 만들어 보겠습니다. 먼저 생성기를 정의합니다:"
    ]
   },
   {
@@ -161,7 +174,7 @@
    "id": "b0b276e7-c392-4eec-be75-c77bd130379d",
    "metadata": {},
    "source": [
-    "### Reflect"
+    "### 반성하기"
    ]
   },
   {
@@ -238,9 +251,9 @@
    "id": "6daf926c-1174-4e96-91b9-57c57cfce40d",
    "metadata": {},
    "source": [
-    "### Repeat\n",
+    "### 반복하기\n",
     "\n",
-    "And... that's all there is too it! You can repeat in a loop for a fixed number of steps, or use an LLM (or other check) to decide when the finished product is good enough."
+    "이게 전부입니다! 고정된 횟수만큼 루프를 반복하거나, LLM(또는 다른 점검 절차)을 사용해 결과물이 충분히 만족스러운 시점을 결정할 수 있습니다."
    ]
   },
   {
@@ -307,9 +320,9 @@
    "id": "b63a9d93-a14d-4e41-a4bb-a4cd31713f44",
    "metadata": {},
    "source": [
-    "## Define graph\n",
+    "## 그래프 정의하기\n",
     "\n",
-    "Now that we've shown each step in isolation, we can wire it up in a graph."
+    "각 단계를 개별적으로 살펴봤으니, 이제 그래프에 연결해 보겠습니다."
    ]
   },
   {
@@ -605,9 +618,9 @@
     "jp-MarkdownHeadingCollapsed": true
    },
    "source": [
-    "## Conclusion\n",
+    "## 마무리\n",
     "\n",
-    "Now that you've applied reflection to an LLM agent, I'll note one thing: self-reflection is inherently cyclic: it is much more effective if the reflection step has additional context or feedback (from tool observations, checks, etc.). If, like in the scenario above, the reflection step simply prompts the LLM to reflect on its output, it can still benefit the output quality (since the LLM then has multiple \"shots\" at getting a good output), but it's less guaranteed.\n"
+    "이제 LLM 에이전트에 반성을 적용했으니 한 가지를 덧붙이겠습니다. 자기 반성은 본질적으로 순환적이므로, 반성 단계에 추가적인 맥락이나 피드백(도구 관찰, 점검 결과 등)이 제공될 때 훨씬 더 효과적입니다. 위 시나리오처럼 반성 단계가 단순히 LLM에게 자신의 출력을 되돌아보도록 요청하는 경우에도 출력 품질 향상에 도움이 될 수 있습니다(여러 번의 시도를 통해 더 나은 답을 얻을 수 있으므로), 다만 항상 보장되는 것은 아닙니다."
    ]
   }
  ],

--- a/examples/reflection/reflection.ipynb
+++ b/examples/reflection/reflection.ipynb
@@ -5,7 +5,7 @@
    "id": "658773a2",
    "metadata": {},
    "source": [
-    "This file has been moved to https://github.com/langchain-ai/langgraph/blob/main/docs/docs/tutorials/reflection/reflection.ipynb"
+    "이 파일은 https://github.com/langchain-ai/langgraph/blob/main/docs/docs/tutorials/reflection/reflection.ipynb 위치로 이동되었습니다."
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- translate the reflection tutorial notebook markdown content into Korean, including the LangSmith tip
- add a Korean overview cell summarizing the five-paragraph essay reflection example
- localize the redirect note in the examples reflection notebook

## Testing
- not run (docs changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d927cb9b408324b45c7cb8950f6581